### PR TITLE
Fix warnings

### DIFF
--- a/effects/candy_cane.yaml
+++ b/effects/candy_cane.yaml
@@ -10,9 +10,9 @@ addressable_lambda:
     }
 
     if(state < width/2){
-      it[0] = ESPColor(255,0,0);
+      it[0] = esphome::Color(255,0,0);
     } else {
-      it[0] = ESPColor::WHITE;
+      it[0] = esphome::Color::WHITE;
     }
 
     state += 1;

--- a/effects/lightning.yaml
+++ b/effects/lightning.yaml
@@ -13,7 +13,7 @@ addressable_lambda:
     if (!frame) { // first frame
       flashes = 4 + random(5);
       next_frame = flashes * 2 + 5 + random(255);
-      it.all() = COLOR_BLACK;
+      it.all() = esphome::Color::BLACK;
     }
     if (frame == 0) { // first frame less intensity
       it.range(px_start, px_end) = current_color * 63;
@@ -22,7 +22,7 @@ addressable_lambda:
       it.range(px_start, px_end) = current_color * bri;
       flashes--;
     } else {
-      it.all() = COLOR_BLACK;
+      it.all() = esphome::Color::BLACK;
     }
     frame++;
     if (frame >= next_frame) frame = 0; // Reset frames


### PR DESCRIPTION
This commit fixes warnings that are given by esphome because of changes to the color structure.
See the lightning effect for example:
```
/config/substitutions/esphome_led_effects/effects/lightning.yaml: In lambda function:
/config/substitutions/esphome_led_effects/effects/lightning.yaml:15:20: warning: 'esphome::COLOR_BLACK' is deprecated: Use Color::BLACK instead of COLOR_BLACK [-Wdeprecated-declarations]
   15 |       it.all() = COLOR_BLACK;
      |                    ^~~~~~~~~~ 
In file included from src/esphome/components/light/addressable_light.h:5,
                 from src/esphome.h:21,
                 from src/main.cpp:3:
src/esphome/core/color.h:177:20: note: declared here
  177 | extern const Color COLOR_BLACK;
      |                    ^~~~~~~~~~~
/config/substitutions/esphome_led_effects/effects/lightning.yaml:24:20: warning: 'esphome::COLOR_BLACK' is deprecated: Use Color::BLACK instead of COLOR_BLACK [-Wdeprecated-declarations]
   24 |       it.all() = COLOR_BLACK;
      |                    ^~~~~~~~~~ 
In file included from src/esphome/components/light/addressable_light.h:5,
                 from src/esphome.h:21,
                 from src/main.cpp:3:
src/esphome/core/color.h:177:20: note: declared here
  177 | extern const Color COLOR_BLACK;
      |                    ^~~~~~~~~~~
```